### PR TITLE
added some Cate and rewrote makefile

### DIFF
--- a/.catel
+++ b/.catel
@@ -1,0 +1,2 @@
+dir cate
+default c_cpp.cate

--- a/cate/c.cate
+++ b/cate/c.cate
@@ -1,0 +1,17 @@
+Library castle(dynamic);
+castle.compiler = "clang";
+castle.flags = "-std=c17 -O3 -fasm -fms-extensions";
+castle.out = "build/libheliumccastle.so";
+castle.files = recursive("src/c/castle/*.c");
+castle.includes = {"src/c/castle/"};
+castle.object_folder = "obj/";
+castle.build();
+
+Library nbt(dynamic);
+nbt.compiler = "clang";
+nbt.flags = "-std=c17 -O3 -fasm -fms-extensions";
+nbt.out = "build/libheliumcnbt.so";
+nbt.files = recursive("src/c/nbt/*.c");
+nbt.includes = {"src/c/nbt/"};
+nbt.object_folder = "obj/";
+nbt.build();

--- a/cate/c_castle.cate
+++ b/cate/c_castle.cate
@@ -1,0 +1,8 @@
+Library castle(dynamic);
+castle.compiler = "clang";
+castle.flags = "-std=c17 -O3 -fasm -fms-extensions";
+castle.out = "build/libheliumccastle.so";
+castle.files = recursive("src/c/castle/*.c");
+castle.includes = {"src/c/castle/"};
+castle.object_folder = "obj/";
+castle.build();

--- a/cate/c_cpp.cate
+++ b/cate/c_cpp.cate
@@ -1,0 +1,2 @@
+system("cate c.cate");
+system("cate cpp.cate");

--- a/cate/c_nbt.cate
+++ b/cate/c_nbt.cate
@@ -1,0 +1,8 @@
+Library nbt(dynamic);
+nbt.compiler = "clang";
+nbt.flags = "-std=c17 -O3 -fasm -fms-extensions";
+nbt.out = "build/libheliumcnbt.so";
+nbt.files = recursive("src/c/nbt/*.c");
+nbt.includes = {"src/c/nbt/"};
+nbt.object_folder = "obj/";
+nbt.build();

--- a/cate/cpp.cate
+++ b/cate/cpp.cate
@@ -1,0 +1,17 @@
+Library castle(dynamic);
+castle.compiler = "clang++";
+castle.flags = "-std=c++17 -Ofast -fasm -fms-extensions";
+castle.out = "build/libheliumcppcastle.so";
+castle.files = recursive("src/cpp/castle/*.cpp");
+castle.includes = {"src/cpp/castle/"};
+castle.object_folder = "obj/";
+castle.build();
+
+Library nbt(dynamic);
+nbt.compiler = "clang++";
+nbt.flags = "-std=c++17 -Ofast -fasm -fms-extensions";
+nbt.out = "build/libheliumcppnbt.so";
+nbt.files = recursive("src/cpp/nbt/*.cpp");
+nbt.includes = {"src/cpp/nbt/"};
+nbt.object_folder = "obj/";
+nbt.build();

--- a/cate/cpp_castle.cate
+++ b/cate/cpp_castle.cate
@@ -1,0 +1,8 @@
+Library castle(dynamic);
+castle.compiler = "clang++";
+castle.flags = "-std=c++17 -Ofast -fasm -fms-extensions";
+castle.out = "build/libheliumcppcastle.so";
+castle.files = recursive("src/cpp/castle/*.cpp");
+castle.includes = {"src/cpp/castle/"};
+castle.object_folder = "obj/";
+castle.build();

--- a/cate/cpp_nbt.cate
+++ b/cate/cpp_nbt.cate
@@ -1,0 +1,8 @@
+Library nbt(dynamic);
+nbt.compiler = "clang++";
+nbt.flags = "-std=c++17 -Ofast -fasm -fms-extensions";
+nbt.out = "build/libheliumcppnbt.so";
+nbt.files = recursive("src/cpp/nbt/*.cpp");
+nbt.includes = {"src/cpp/nbt/"};
+nbt.object_folder = "obj/";
+nbt.build();

--- a/makefile
+++ b/makefile
@@ -1,4 +1,14 @@
+#Better Makefile for Helium Serialization. written by Kryog team
 .PHONY : clean nbt castle dotnet c cpp dotnet_nbt dotnet_castle c_nbt c_castle cpp_nbt cpp_castle
+
+MKD = mkdir
+#WARNING: OS-detection in a turing complete build system
+ifeq ($(OS),Windows_NT)
+	RM = del /s /q 
+else
+	RM = rm -rf
+	MKD += -p 
+endif
 
 #Compilers
 C_COMPILER = clang
@@ -44,30 +54,38 @@ DOTNET_CASTLE_DIRECTORIES := Helium.Serialization.Common
 
 DOTNET_CASTLE_FILES := $(foreach dir, $(DOTNET_CASTLE_DIRECTORIES), $(wildcard $(dir)/*))
 
+#nice aliases
 all: dotnet c cpp
 
 c: c_castle c_nbt
 cpp: cpp_castle cpp_nbt
 
+#prevent relinking when it's not needed
+c_castle: $(LIB_OUT_DIR)/libheliumccastle.so
+cpp_castle: $(LIB_OUT_DIR)/libheliumcppcastle.so
+c_nbt: $(LIB_OUT_DIR)/libheliumcnbt.so
+cpp_nbt: $(LIB_OUT_DIR)/libheliumcppnbt.so
+
 #setup
 setup: 
-	@mkdir -p $(C_CASTLE_OBJ_DIR) $(CPP_CASTLE_OBJ_DIR)
-	@mkdir -p $(LIB_OUT_DIR)
-	@echo Ready
+	@$(MKD) $(C_CASTLE_OBJ_DIR) $(CPP_CASTLE_OBJ_DIR)
+	@$(MKD) $(LIB_OUT_DIR)
+	@$(MKD) Ready
 
-#Building
-c_castle: $(C_CASTLE_OBJ)
-	@$(C_COMPILER) -shared $^ -o $(LIB_OUT_DIR)/libheliumccastle.so
+#Building objects
+$(LIB_OUT_DIR)/libheliumccastle.so: $(C_CASTLE_OBJ)
+	@$(C_COMPILER) -shared $^ -o $@
 
-cpp_castle: $(CPP_CASTLE_OBJ)
-	@$(CPP_COMPILER) -shared $^ -o $(LIB_OUT_DIR)/libheliumcppcastle.so
+$(LIB_OUT_DIR)/libheliumcppcastle.so: $(CPP_CASTLE_OBJ)
+	@$(CPP_COMPILER) -shared $^ -o $@
 
-c_nbt: $(C_CASTLE_OBJ)
-	@$(C_COMPILER) -shared $^ -o $(LIB_OUT_DIR)/libheliumcnbt.so
+$(LIB_OUT_DIR)/libheliumcnbt.so: $(C_CASTLE_OBJ)
+	@$(C_COMPILER) -shared $^ -o $@
 
-cpp_nbt: $(CPP_CASTLE_OBJ)
-	@$(CPP_COMPILER) -shared $^ -o $(LIB_OUT_DIR)/libheliumcppnbt.so
+$(LIB_OUT_DIR)/libheliumcppnbt.so: $(CPP_CASTLE_OBJ)
+	@$(CPP_COMPILER) -shared $^ -o $@
 
+#Whatever dotnet does
 dotnet: $(wildcard $(DOTNET_SRC/*))
 	@dotnet pack -o $(LIB_OUT_DIR) -p:SymbolPackageFormat=snupkg --include-symbols --include-source
 
@@ -79,7 +97,9 @@ dotnet_castle: $(DOTNET_CASTLE_FILES)
 
 #cleaning up :D
 clean:
-	rm -rf $(OBJ) $(LIB_OUT_DIR)
+	$(RM) $(OBJ) $(LIB_OUT_DIR)
+
+
 
 
 

--- a/makefile
+++ b/makefile
@@ -70,7 +70,7 @@ endif
 setup_linux: 
 	@$(MKD) $(C_CASTLE_OBJ_DIR) $(CPP_CASTLE_OBJ_DIR)
 	@$(MKD) $(LIB_OUT_DIR)
-	@$(MKD) Ready
+	@echo Ready
 
 #Building final library 
 $(LIB_OUT_DIR)/libheliumccastle.so: $(C_CASTLE_OBJ)

--- a/makefile
+++ b/makefile
@@ -1,14 +1,5 @@
 #Better Makefile for Helium Serialization. written by Kryog team
-.PHONY : clean nbt castle dotnet c cpp dotnet_nbt dotnet_castle c_nbt c_castle cpp_nbt cpp_castle
-
-MKD = mkdir
-#WARNING: OS-detection in a turing complete build system
-ifeq ($(OS),Windows_NT)
-	RM = del /s /q 
-else
-	RM = rm -rf
-	MKD += -p 
-endif
+.PHONY : clean setup_linux nbt castle dotnet c cpp dotnet_nbt dotnet_castle c_nbt c_castle cpp_nbt cpp_castle
 
 #Compilers
 C_COMPILER = clang
@@ -66,13 +57,22 @@ cpp_castle: $(LIB_OUT_DIR)/libheliumcppcastle.so
 c_nbt: $(LIB_OUT_DIR)/libheliumcnbt.so
 cpp_nbt: $(LIB_OUT_DIR)/libheliumcppnbt.so
 
+MKD = mkdir
+#OS-detection in a turing complete build system
+ifeq ($(OS),Windows_NT)
+	RM = del /s /q 
+else
+	RM = rm -rf
+	MKD += -p 
+endif
+
 #setup
-setup: 
+setup_linux: 
 	@$(MKD) $(C_CASTLE_OBJ_DIR) $(CPP_CASTLE_OBJ_DIR)
 	@$(MKD) $(LIB_OUT_DIR)
 	@$(MKD) Ready
 
-#Building objects
+#Building final library 
 $(LIB_OUT_DIR)/libheliumccastle.so: $(C_CASTLE_OBJ)
 	@$(C_COMPILER) -shared $^ -o $@
 
@@ -100,7 +100,7 @@ clean:
 	$(RM) $(OBJ) $(LIB_OUT_DIR)
 
 
-
+#CW: makefile syntax
 
 
 #ignore these please, these are literal black magic

--- a/makefile
+++ b/makefile
@@ -1,38 +1,17 @@
-#Better Makefile for Helium Serialization. written by Kryog team
-.PHONY : clean setup_linux nbt castle dotnet c cpp dotnet_nbt dotnet_castle c_nbt c_castle cpp_nbt cpp_castle
-
-#Compilers
-C_COMPILER = clang
-CPP_COMPILER = clang++
-
-#Flags
-CPP_FLAGS = -std=c++17 -Ofast -fasm -fms-extensions
-C_FLAGS = -std=c17 -O3 -fasm -fms-extensions
-
-#Sources
-C_SRC = src/c
-CPP_SRC = src/cpp
+.PHONY : clean nbt castle dotnet c cpp dotnet_nbt dotnet_castle c_nbt c_castle cpp_nbt cpp_castle
 DOTNET_COMPILER = dotnet build
 DOTNET_SRC = src/csharp
+C_COMPILER = clang
+CPP_COMPILER = clang++
+C_SRC = src/c
+CPP_SRC = src/cpp
+BUILD := build
+TEMP_DIRECTORY := temp
+C_NBT_OBJ_DIR := obj/c/nbt
+C_CASTLE_OBJ_DIR := obj/c/castle
+CPP_NBT_OBJ_DIR := obj/cpp/nbt
+CPP_CASTLE_OBJ_DIR := obj/cpp/castle
 
-#build directories
-LIB_OUT_DIR = build
-OBJ = obj
-
-#add your files to OBJ, like this: $(C_CASTLE_OBJ_DIR)/filename.o (the .o is important)
-C_CASTLE_OBJ_DIR = $(OBJ)/c/castle
-C_CASTLE_OBJ = $(C_CASTLE_OBJ_DIR)/castle_index.o
-
-CPP_CASTLE_OBJ_DIR = $(OBJ)/cpp/castle
-CPP_CASTLE_OBJ = $(CPP_CASTLE_OBJ_DIR)/dummy.o
-
-C_NBT_OBJ_DIR = $(OBJ)/c/nbt
-C_NBT_OBJ = $(C_NBT_OBJ_DIR)/dummy.o
-
-CPP_NBT_OBJ_DIR = $(OBJ)/cpp/nbt
-CPP_NBT_OBJ = $(CPP_NBT_OBJ_DIR)/dummy.o
-
-#idk dotnet
 # todo: add more to these as more are created
 DOTNET_NBT_DIRECTORIES := Helium.Serialization.Common \
 	Helium.Serialization.Nbt \
@@ -45,49 +24,34 @@ DOTNET_CASTLE_DIRECTORIES := Helium.Serialization.Common
 
 DOTNET_CASTLE_FILES := $(foreach dir, $(DOTNET_CASTLE_DIRECTORIES), $(wildcard $(dir)/*))
 
-#nice aliases
-all: dotnet c cpp
+CPP_FLAGS = -std=c++17 -Ofast -fasm -fms-extensions
+C_FLAGS = -std=c17 -O3 -fasm -fms-extensions
 
-c: c_castle c_nbt
-cpp: cpp_castle cpp_nbt
+C_NBT_FILES := $(wildcard $(C_SRC)/nbt/*.c)
+C_CASTLE_FILES := $(wildcard $(C_SRC)/castle/*.c)
 
-#prevent relinking when it's not needed
-c_castle: $(LIB_OUT_DIR)/libheliumccastle.so
-cpp_castle: $(LIB_OUT_DIR)/libheliumcppcastle.so
-c_nbt: $(LIB_OUT_DIR)/libheliumcnbt.so
-cpp_nbt: $(LIB_OUT_DIR)/libheliumcppnbt.so
+CPP_NBT_FILES := $(wildcard $(CPP_SRC)/nbt/*.cpp) $(C_NBT_FILES)
+CPP_CASTLE_FILES := $(wildcard $(CPP_SRC)/nbt/*.cpp) $(CPP_NBT_FILES)
 
-MKD = mkdir
-#OS-detection in a turing complete build system
-ifeq ($(OS),Windows_NT)
-	RM = del /s /q 
-else
-	RM = rm -rf
-	MKD += -p 
-endif
+C_NBT_OBJECTS := $(patsubst $(C_NBT_FILES)/%.c, $(C_NBT_OBJ_DIR)/%.o, $(C_NBT_FILES))
+C_CASTLE_OBJECTS := $(patsubst $(C_CASTLE_FILES)/%.c, $(C_CASTLE_OBJ_DIR)/%.o, $(C_CASTLE_FILES))
 
-#setup
-setup_linux: 
-	@$(MKD) $(C_CASTLE_OBJ_DIR) $(CPP_CASTLE_OBJ_DIR)
-	@$(MKD) $(LIB_OUT_DIR)
-	@echo Ready
+CPP_NBT_OBJECTS := $(patsubst $(CPP_NBT_FILES)/%.c, $(CPP_NBT_OBJ_DIR)/%.o, $(CPP_NBT_FILES))
+CPP_CASTLE_OBJECTS := $(patsubst $(CPP_CASTLE_FILES)/%.c, $(CPP_CASTLE_OBJ_DIR)/%.o, $(CPP_CASTLE_FILES))
 
-#Building final library 
-$(LIB_OUT_DIR)/libheliumccastle.so: $(C_CASTLE_OBJ)
-	@$(C_COMPILER) -shared $^ -o $@
+all : dotnet c cpp
 
-$(LIB_OUT_DIR)/libheliumcppcastle.so: $(CPP_CASTLE_OBJ)
-	@$(CPP_COMPILER) -shared $^ -o $@
+nbt : dotnet_nbt c_nbt cpp_nbt
 
-$(LIB_OUT_DIR)/libheliumcnbt.so: $(C_CASTLE_OBJ)
-	@$(C_COMPILER) -shared $^ -o $@
+castle : dotnet_castle c_castle cpp_castle
 
-$(LIB_OUT_DIR)/libheliumcppnbt.so: $(CPP_CASTLE_OBJ)
-	@$(CPP_COMPILER) -shared $^ -o $@
+# for dotnet we actually have a shared library to build
+dotnet : $(wildcard $(DOTNET_SRC/*))
+	@dotnet pack -o $(BUILD) -p:SymbolPackageFormat=snupkg --include-symbols --include-source
 
-#Whatever dotnet does
-dotnet: $(wildcard $(DOTNET_SRC/*))
-	@dotnet pack -o $(LIB_OUT_DIR) -p:SymbolPackageFormat=snupkg --include-symbols --include-source
+c : c_nbt c_castle
+
+cpp : cpp_nbt cpp_castle
 
 dotnet_nbt : $(DOTNET_NBT_FILES)
 	@dotnet pack -o $(BUILD) ./$(DOTNET_SRC)/Helium.Serialization.Nbt -p:SymbolPackageFormat=snupkg --include-symbols --include-source
@@ -95,23 +59,30 @@ dotnet_nbt : $(DOTNET_NBT_FILES)
 dotnet_castle: $(DOTNET_CASTLE_FILES)
 	@dotnet pack -o $(BUILD) ./$(DOTNET_SRC)/Helium.Serialization.Castle -p:SymbolPackageFormat=snupkg --include-symbols --include-source 
 
-#cleaning up :D
-clean:
-	$(RM) $(OBJ) $(LIB_OUT_DIR)
+c_nbt : $(C_NBT_OBJECTS)
+	@$(C_COMPILER) -shared $^ -o $(BUILD)/libheliumcnbt.so
 
+c_castle : $(C_CASTLE_OBJECTS)
+	@$(C_COMPILER) -shared $^ -o $(BUILD)/libheliumccastle.so
 
-#CW: makefile syntax
+cpp_nbt : $(CPP_NBT_OBJECTS)
+	@$(C_COMPILER) -shared $^ -o $(BUILD)/libheliumcppnbt.so
 
+cpp_castle : $(CPP_CASTLE_OBJECTS)
+	@$(C_COMPILER) -shared $^ -o $(BUILD)/libheliumcppcastle.so
 
-#ignore these please, these are literal black magic
-$(C_CASTLE_OBJ_DIR)/%.o: $(C_SRC)/castle/%.c
-	@$(C_COMPILER) $(C_FLAGS) -c $< -o $@
+$(C_NBT_OBJ_DIR)/%.o : $(C_NBT_FILES)
+	@$(C_COMPILER) -I$(C_NBT_FILES) $(C_FLAGS) -c $< -o $@
 
-$(CPP_CASTLE_OBJ_DIR)/%.o: $(CPP_SRC)/castle/%.cpp
-	@$(C_COMPILER) $(CPP_FLAGS) -c $< -o $@
+$(C_CASTLE_OBJ_DIR)/%.o : $(C_CASTLE_FILES)
+	@$(C_COMPILER) -I$(C_CASTLE_FILES) $(C_FLAGS) -c $< -o $@
 
-$(C_NBT_OBJ_DIR)/%.o: $(C_SRC)/nbt/%.c
-	@$(C_COMPILER) $(C_FLAGS) -c $< -o $@
+$(CPP_NBT_OBJ_DIR)/%.o : $(CPP_NBT_FILES)
+	@$(CPP_COMPILER) -I$(C_NBT_FILES) $(C_FLAGS) -c $< -o $@
 
-$(CPP_NBT_OBJ_DIR)/%.o: $(CPP_SRC)/nbt/%.cpp
-	@$(C_COMPILER) $(CPP_FLAGS) -c $< -o $@
+$(CPP_CASTLE_OBJ_DIR)/%.o : $(CPP_CASTLE_FILES)
+	@$(CPP_COMPILER) -I$(CPP_CASTLE_FILES) $(CPP_FLAGS) -c $< -o $@
+
+clean : 
+	-rm -rf $(BUILD)
+	-rm -rf obj


### PR DESCRIPTION
I know most of you people have no idea what Cate is, basically it's a painless build system! While Cate is not really fast, it saves **hours** of Makefile pain! Cate only builds C/C++ though.

The C++ NBT Catefile is
```css
Library nbt(dynamic);
nbt.compiler = "clang++";
nbt.flags = "-std=c++17 -Ofast -fasm -fms-extensions";
nbt.out = "build/libheliumcppnbt.so";
nbt.files = recursive("src/cpp/nbt/*.cpp");
nbt.includes = {"src/cpp/nbt/"};
nbt.object_folder = "obj/";
nbt.build();
```
Which is much easier to comprehend than
```make
CPP_NBT_FILES := $(wildcard $(CPP_SRC)/nbt/*.cpp) $(C_NBT_FILES)
CPP_NBT_OBJECTS := $(patsubst $(CPP_NBT_FILES)/%.c, $(CPP_NBT_OBJ_DIR)/%.o, $(CPP_NBT_FILES))

cpp_nbt : $(CPP_NBT_OBJECTS)
	@$(C_COMPILER) -shared $^ -o $(BUILD)/libheliumcppnbt.so

$(CPP_NBT_OBJ_DIR)/%.o : $(CPP_NBT_FILES)
	@$(CPP_COMPILER) -I$(C_NBT_FILES) $(C_FLAGS) -c $< -o $@
```

Cate also creates directories automatically, saving the poor soul who has to deal with Makefile a bit of sanity.

Also, fixed your makefile

Hope this could help you!
-yogurt (ae/aem)